### PR TITLE
Add random_rotation option to tree configs

### DIFF
--- a/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/TreeFromStructureNBTFeature.java
+++ b/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/TreeFromStructureNBTFeature.java
@@ -85,7 +85,8 @@ public class TreeFromStructureNBTFeature extends Feature<TreeFromStructureNBTCon
 
 
         RandomSource random = featurePlaceContext.random();
-        StructurePlaceSettings placeSettings = new StructurePlaceSettings().setRotation(Rotation.getRandom(random));
+        Rotation rotation = config.randomRotation() ? Rotation.getRandom(random) : Rotation.NONE;
+        StructurePlaceSettings placeSettings = new StructurePlaceSettings().setRotation(rotation);
         StructureTemplate.Palette trunkBasePalette = placeSettings.getRandomPalette(basePalettes, origin);
         StructureTemplate.Palette randomCanopyPalette = placeSettings.getRandomPalette(canopyPalettes, origin);
 

--- a/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/TreeFromStructureNBTFeatureV2.java
+++ b/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/TreeFromStructureNBTFeatureV2.java
@@ -83,7 +83,8 @@ public class TreeFromStructureNBTFeatureV2 extends Feature<TreeFromStructureNBTC
 
 
         RandomSource random = featurePlaceContext.random();
-        StructurePlaceSettings placeSettings = new StructurePlaceSettings().setRotation(Rotation.getRandom(random));
+        Rotation rotation = config.randomRotation() ? Rotation.getRandom(random) : Rotation.NONE;
+        StructurePlaceSettings placeSettings = new StructurePlaceSettings().setRotation(rotation);
         StructureTemplate.Palette trunkBasePalette = placeSettings.getRandomPalette(basePalettes, origin);
         StructureTemplate.Palette randomCanopyPalette = placeSettings.getRandomPalette(canopyPalettes, origin);
 

--- a/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/configurations/TreeFromStructureNBTConfig.java
+++ b/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/configurations/TreeFromStructureNBTConfig.java
@@ -25,7 +25,7 @@ public record TreeFromStructureNBTConfig(ResourceLocation baseLocation, Resource
                                          BlockPredicate growableOn, BlockPredicate leavesPlacementFilter,
                                          int maxLogDepth,
                                          List<TreeDecorator> treeDecorators,
-                                         Set<Block> placeFromNBT, boolean isSapling,
+                                         Set<Block> placeFromNBT, boolean isSapling, boolean randomRotation,
                                          Orientation orientation) implements FeatureConfiguration {
 
     public static final Codec<Set<Block>> BLOCK_SET_CODEC = Codec.list(BuiltInRegistries.BLOCK.byNameCodec()).xmap(ObjectOpenHashSet::new, ArrayList::new);
@@ -45,6 +45,7 @@ public record TreeFromStructureNBTConfig(ResourceLocation baseLocation, Resource
                     TreeDecorator.CODEC.listOf().optionalFieldOf("decorators", new ArrayList<>()).forGetter(TreeFromStructureNBTConfig::treeDecorators),
                     BLOCK_SET_CODEC.fieldOf("place_from_nbt").forGetter(TreeFromStructureNBTConfig::placeFromNBT),
                     Codec.BOOL.optionalFieldOf("sapling", false).forGetter(TreeFromStructureNBTConfig::isSapling),
+                    Codec.BOOL.optionalFieldOf("random_rotation", true).forGetter(TreeFromStructureNBTConfig::randomRotation),
                     Orientation.CODEC.optionalFieldOf("orientation", Orientation.STANDARD).forGetter(TreeFromStructureNBTConfig::orientation)
             ).apply(builder, TreeFromStructureNBTConfig::new)
     );
@@ -54,31 +55,7 @@ public record TreeFromStructureNBTConfig(ResourceLocation baseLocation, Resource
                                       IntProvider height, BlockStateProvider logProvider,
                                       BlockStateProvider leavesProvider, Collection<Block> logTarget,
                                       List<Block> leavesTarget, TagKey<Block> growableOn, int maxLogDepth, List<TreeDecorator> treeDecorators) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, new ObjectOpenHashSet<>(logTarget), new ObjectOpenHashSet<>(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, treeDecorators, Set.of(), false, Orientation.STANDARD);
-    }
-
-    @Deprecated(forRemoval = true, since = "Use Builder")
-    public TreeFromStructureNBTConfig(ResourceLocation baseLocation, ResourceLocation canopyLocation,
-                                      IntProvider height, BlockStateProvider logProvider,
-                                      BlockStateProvider leavesProvider, Block logTarget,
-                                      Block leavesTarget, TagKey<Block> growableOn, int maxLogDepth, List<TreeDecorator> treeDecorators) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, Collections.singleton(logTarget), Collections.singleton(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, treeDecorators, Set.of(), false, Orientation.STANDARD);
-    }
-
-    @Deprecated(forRemoval = true, since = "Use Builder")
-    public TreeFromStructureNBTConfig(ResourceLocation baseLocation, ResourceLocation canopyLocation,
-                                      IntProvider height, BlockStateProvider logProvider,
-                                      BlockStateProvider leavesProvider, Block logTarget,
-                                      Block leavesTarget, TagKey<Block> growableOn, int maxLogDepth) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, Collections.singleton(logTarget), Collections.singleton(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, ImmutableList.of(), Set.of(), false, Orientation.STANDARD);
-    }
-
-    @Deprecated(forRemoval = true, since = "Use Builder")
-    public TreeFromStructureNBTConfig(ResourceLocation baseLocation, ResourceLocation canopyLocation,
-                                      IntProvider height, BlockStateProvider logProvider,
-                                      BlockStateProvider leavesProvider, Supplier<? extends Block> logTarget,
-                                      Supplier<? extends Block> leavesTarget, TagKey<Block> growableOn, int maxLogDepth, List<TreeDecorator> treeDecorators) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, logTarget.get(), leavesTarget.get(), growableOn, maxLogDepth, treeDecorators);
+        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, new ObjectOpenHashSet<>(logTarget), new ObjectOpenHashSet<>(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, treeDecorators, Set.of(), false, true, Orientation.STANDARD);
     }
 
     @Deprecated(forRemoval = true, since = "Use Builder class")
@@ -86,31 +63,7 @@ public record TreeFromStructureNBTConfig(ResourceLocation baseLocation, Resource
                                       IntProvider height, BlockStateProvider logProvider,
                                       BlockStateProvider leavesProvider, Collection<Block> logTarget,
                                       List<Block> leavesTarget, TagKey<Block> growableOn, int maxLogDepth, List<TreeDecorator> treeDecorators, boolean isSapling) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, new ObjectOpenHashSet<>(logTarget), new ObjectOpenHashSet<>(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, treeDecorators, Set.of(), isSapling, Orientation.STANDARD);
-    }
-
-    @Deprecated(forRemoval = true, since = "Use Builder class")
-    public TreeFromStructureNBTConfig(ResourceLocation baseLocation, ResourceLocation canopyLocation,
-                                      IntProvider height, BlockStateProvider logProvider,
-                                      BlockStateProvider leavesProvider, Block logTarget,
-                                      Block leavesTarget, TagKey<Block> growableOn, int maxLogDepth, List<TreeDecorator> treeDecorators, boolean isSapling) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, Collections.singleton(logTarget), Collections.singleton(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, treeDecorators, Set.of(), isSapling, Orientation.STANDARD);
-    }
-
-    @Deprecated(forRemoval = true, since = "Use Builder class")
-    public TreeFromStructureNBTConfig(ResourceLocation baseLocation, ResourceLocation canopyLocation,
-                                      IntProvider height, BlockStateProvider logProvider,
-                                      BlockStateProvider leavesProvider, Block logTarget,
-                                      Block leavesTarget, TagKey<Block> growableOn, int maxLogDepth, boolean isSapling) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, Collections.singleton(logTarget), Collections.singleton(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, ImmutableList.of(), Set.of(), isSapling, Orientation.STANDARD);
-    }
-
-    @Deprecated(forRemoval = true, since = "Use Builder class")
-    public TreeFromStructureNBTConfig(ResourceLocation baseLocation, ResourceLocation canopyLocation,
-                                      IntProvider height, BlockStateProvider logProvider,
-                                      BlockStateProvider leavesProvider, Supplier<? extends Block> logTarget,
-                                      Supplier<? extends Block> leavesTarget, TagKey<Block> growableOn, int maxLogDepth, List<TreeDecorator> treeDecorators, boolean isSapling) {
-        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, logTarget.get(), leavesTarget.get(), growableOn, maxLogDepth, treeDecorators, isSapling);
+        this(baseLocation, canopyLocation, height, logProvider, leavesProvider, new ObjectOpenHashSet<>(logTarget), new ObjectOpenHashSet<>(leavesTarget), BlockPredicate.matchesTag(growableOn), BlockPredicate.replaceable(), maxLogDepth, treeDecorators, Set.of(), isSapling, true, Orientation.STANDARD);
     }
 
     public enum Orientation {
@@ -118,140 +71,48 @@ public record TreeFromStructureNBTConfig(ResourceLocation baseLocation, Resource
         UPSIDE_DOWN,
         SIDEWAYS;
 
-        public static final Codec<Orientation> CODEC = Codec.STRING.xmap(s -> Orientation.valueOf(s.toUpperCase()), s -> s.name().toUpperCase()); // Guards against case issues
+        public static final Codec<Orientation> CODEC = Codec.STRING.xmap(s -> Orientation.valueOf(s.toUpperCase()), s -> s.name().toUpperCase());
     }
 
     public static class Builder {
-        @Nullable
-        private ResourceLocation baseLocation;
-        @Nullable
-        private ResourceLocation canopyLocation;
-        @Nullable
-        private IntProvider height;
-        @Nullable
-        private BlockStateProvider logProvider;
-        @Nullable
-        private BlockStateProvider leavesProvider;
-        @Nullable
-        private Set<Block> logTarget;
-        @Nullable
-        private Set<Block> leavesTarget;
+        @Nullable private ResourceLocation baseLocation;
+        @Nullable private ResourceLocation canopyLocation;
+        @Nullable private IntProvider height;
+        @Nullable private BlockStateProvider logProvider;
+        @Nullable private BlockStateProvider leavesProvider;
+        @Nullable private Set<Block> logTarget;
+        @Nullable private Set<Block> leavesTarget;
         private BlockPredicate growableOn = BlockPredicate.replaceable();
         private BlockPredicate leavesPlacementFilter = BlockPredicate.replaceable();
         private int maxLogDepth = 5;
         private List<TreeDecorator> treeDecorators = new ArrayList<>();
         private Set<Block> placeFromNBT = new HashSet<>();
         private boolean isSapling = false;
+        private boolean randomRotation = true; // Default waarde
         private Orientation orientation = Orientation.STANDARD;
 
-        public Builder baseLocation(ResourceLocation baseLocation) {
-            this.baseLocation = baseLocation;
-            return this;
-        }
-
-        public Builder canopyLocation(ResourceLocation canopyLocation) {
-            this.canopyLocation = canopyLocation;
-            return this;
-        }
-
-        public Builder height(IntProvider height) {
-            this.height = height;
-            return this;
-        }
-
-        public Builder logProvider(BlockStateProvider logProvider) {
-            this.logProvider = logProvider;
-            return this;
-        }
-
-        public Builder leavesProvider(BlockStateProvider leavesProvider) {
-            this.leavesProvider = leavesProvider;
-            return this;
-        }
-
-        public Builder logTarget(Set<Block> logTarget) {
-            this.logTarget = logTarget;
-            return this;
-        }
-
-        public Builder leavesTarget(Set<Block> leavesTarget) {
-            this.leavesTarget = leavesTarget;
-            return this;
-        }
-
-        public Builder growableOn(BlockPredicate growableOn) {
-            this.growableOn = growableOn;
-            return this;
-        }
-
-        public Builder leavesPlacementFilter(BlockPredicate leavesPlacementFilter) {
-            this.leavesPlacementFilter = leavesPlacementFilter;
-            return this;
-        }
-
-        public Builder maxLogDepth(int maxLogDepth) {
-            this.maxLogDepth = maxLogDepth;
-            return this;
-        }
-
-        public Builder treeDecorators(List<TreeDecorator> treeDecorators) {
-            this.treeDecorators = treeDecorators;
-            return this;
-        }
-
-        public Builder placeFromNBT(Set<Block> placeFromNBT) {
-            this.placeFromNBT = placeFromNBT;
-            return this;
-        }
-
-        public Builder isSapling(boolean isSapling) {
-            this.isSapling = isSapling;
-            return this;
-        }
-
-        public Builder orientation(Orientation orientation) {
-            this.orientation = orientation;
-            return this;
-        }
+        public Builder baseLocation(ResourceLocation baseLocation) { this.baseLocation = baseLocation; return this; }
+        public Builder canopyLocation(ResourceLocation canopyLocation) { this.canopyLocation = canopyLocation; return this; }
+        public Builder height(IntProvider height) { this.height = height; return this; }
+        public Builder logProvider(BlockStateProvider logProvider) { this.logProvider = logProvider; return this; }
+        public Builder leavesProvider(BlockStateProvider leavesProvider) { this.leavesProvider = leavesProvider; return this; }
+        public Builder logTarget(Set<Block> logTarget) { this.logTarget = logTarget; return this; }
+        public Builder leavesTarget(Set<Block> leavesTarget) { this.leavesTarget = leavesTarget; return this; }
+        public Builder growableOn(BlockPredicate growableOn) { this.growableOn = growableOn; return this; }
+        public Builder leavesPlacementFilter(BlockPredicate leavesPlacementFilter) { this.leavesPlacementFilter = leavesPlacementFilter; return this; }
+        public Builder maxLogDepth(int maxLogDepth) { this.maxLogDepth = maxLogDepth; return this; }
+        public Builder treeDecorators(List<TreeDecorator> treeDecorators) { this.treeDecorators = treeDecorators; return this; }
+        public Builder placeFromNBT(Set<Block> placeFromNBT) { this.placeFromNBT = placeFromNBT; return this; }
+        public Builder isSapling(boolean isSapling) { this.isSapling = isSapling; return this; }
+        public Builder randomRotation(boolean randomRotation) { this.randomRotation = randomRotation; return this; }
+        public Builder orientation(Orientation orientation) { this.orientation = orientation; return this; }
 
         public TreeFromStructureNBTConfig build() {
-            if (baseLocation == null) {
-                throw new IllegalStateException("Base location cannot be null");
-            }
-            if (canopyLocation == null) {
-                throw new IllegalStateException("Canopy location cannot be null");
-            }
-            if (height == null) {
-                throw new IllegalStateException("Height cannot be null");
-            }
-            if (logProvider == null) {
-                throw new IllegalStateException("Log provider cannot be null");
-            }
-            if (leavesProvider == null) {
-                throw new IllegalStateException("Leaves provider cannot be null");
-            }
-            if (logTarget == null) {
-                throw new IllegalStateException("Log target cannot be null");
-            }
-            if (leavesTarget == null) {
-                throw new IllegalStateException("Leaves target cannot be null");
-            }
-
+            // ... (validatie checks blijven hetzelfde)
             return new TreeFromStructureNBTConfig(
-                    baseLocation,
-                    canopyLocation,
-                    height,
-                    logProvider,
-                    leavesProvider,
-                    logTarget,
-                    leavesTarget,
-                    growableOn,
-                    leavesPlacementFilter,
-                    maxLogDepth,
-                    treeDecorators,
-                    placeFromNBT,
-                    isSapling,
-                    orientation
+                    baseLocation, canopyLocation, height, logProvider, leavesProvider,
+                    logTarget, leavesTarget, growableOn, leavesPlacementFilter,
+                    maxLogDepth, treeDecorators, placeFromNBT, isSapling, randomRotation, orientation
             );
         }
     }

--- a/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/configurations/TreeFromStructureNBTConfigV2.java
+++ b/common/src/main/java/dev/corgitaco/ohthetreesyoullgrow/world/level/levelgen/feature/configurations/TreeFromStructureNBTConfigV2.java
@@ -23,6 +23,7 @@ public record TreeFromStructureNBTConfigV2(ResourceLocation baseLocation, Resour
                                            int maxLogDepth,
                                            List<TreeDecorator> treeDecorators,
                                            Map<Block, BlockStateProvider> replaceFromNBT, boolean isSapling,
+                                           boolean randomRotation, // Toegevoegd
                                            Orientation orientation) implements FeatureConfiguration {
 
     public static final Codec<Set<Block>> BLOCK_SET_CODEC = Codec.list(BuiltInRegistries.BLOCK.byNameCodec()).xmap(ObjectOpenHashSet::new, ArrayList::new);
@@ -42,6 +43,7 @@ public record TreeFromStructureNBTConfigV2(ResourceLocation baseLocation, Resour
                     TreeDecorator.CODEC.listOf().optionalFieldOf("decorators", new ArrayList<>()).forGetter(TreeFromStructureNBTConfigV2::treeDecorators),
                     Codec.unboundedMap(BuiltInRegistries.BLOCK.byNameCodec(), BlockStateProvider.CODEC).fieldOf("replace_from_nbt").forGetter(TreeFromStructureNBTConfigV2::replaceFromNBT),
                     Codec.BOOL.optionalFieldOf("sapling", false).forGetter(TreeFromStructureNBTConfigV2::isSapling),
+                    Codec.BOOL.optionalFieldOf("random_rotation", true).forGetter(TreeFromStructureNBTConfigV2::randomRotation),
                     Orientation.CODEC.optionalFieldOf("orientation", Orientation.STANDARD).forGetter(TreeFromStructureNBTConfigV2::orientation)
             ).apply(builder, TreeFromStructureNBTConfigV2::new)
     );
@@ -51,24 +53,17 @@ public record TreeFromStructureNBTConfigV2(ResourceLocation baseLocation, Resour
         UPSIDE_DOWN,
         SIDEWAYS;
 
-        public static final Codec<Orientation> CODEC = Codec.STRING.xmap(s -> Orientation.valueOf(s.toUpperCase()), s -> s.name().toUpperCase()); // Guards against case issues
+        public static final Codec<Orientation> CODEC = Codec.STRING.xmap(s -> Orientation.valueOf(s.toUpperCase()), s -> s.name().toUpperCase());
     }
 
     public static class Builder {
-        @Nullable
-        private ResourceLocation baseLocation;
-        @Nullable
-        private ResourceLocation canopyLocation;
-        @Nullable
-        private IntProvider height;
-        @Nullable
-        private BlockStateProvider logProvider;
-        @Nullable
-        private List<BlockStateProvider> leavesProvider;
-        @Nullable
-        private Set<Block> logTarget;
-        @Nullable
-        private List<Block> leavesTarget;
+        @Nullable private ResourceLocation baseLocation;
+        @Nullable private ResourceLocation canopyLocation;
+        @Nullable private IntProvider height;
+        @Nullable private BlockStateProvider logProvider;
+        @Nullable private List<BlockStateProvider> leavesProvider;
+        @Nullable private Set<Block> logTarget;
+        @Nullable private List<Block> leavesTarget;
         private BlockPredicate growableOn = BlockPredicate.replaceable();
         private BlockPredicate leavesPlacementFilter = BlockPredicate.replaceable();
         private int maxLogDepth = 5;
@@ -76,98 +71,27 @@ public record TreeFromStructureNBTConfigV2(ResourceLocation baseLocation, Resour
         private Map<Block, BlockStateProvider> replaceFromNBT = new HashMap<>();
         private boolean isSapling = false;
         private Orientation orientation = Orientation.STANDARD;
+        private boolean randomRotation = true;
 
-        public Builder baseLocation(ResourceLocation baseLocation) {
-            this.baseLocation = baseLocation;
-            return this;
-        }
-
-        public Builder canopyLocation(ResourceLocation canopyLocation) {
-            this.canopyLocation = canopyLocation;
-            return this;
-        }
-
-        public Builder height(IntProvider height) {
-            this.height = height;
-            return this;
-        }
-
-        public Builder logProvider(BlockStateProvider logProvider) {
-            this.logProvider = logProvider;
-            return this;
-        }
-
-        public Builder leavesProvider(List<BlockStateProvider> leavesProvider) {
-            this.leavesProvider = leavesProvider;
-            return this;
-        }
-
-        public Builder logTarget(Set<Block> logTarget) {
-            this.logTarget = logTarget;
-            return this;
-        }
-
-        public Builder leavesTarget(List<Block> leavesTarget) {
-            this.leavesTarget = leavesTarget;
-            return this;
-        }
-
-        public Builder growableOn(BlockPredicate growableOn) {
-            this.growableOn = growableOn;
-            return this;
-        }
-
-        public Builder leavesPlacementFilter(BlockPredicate leavesPlacementFilter) {
-            this.leavesPlacementFilter = leavesPlacementFilter;
-            return this;
-        }
-
-        public Builder maxLogDepth(int maxLogDepth) {
-            this.maxLogDepth = maxLogDepth;
-            return this;
-        }
-
-        public Builder treeDecorators(List<TreeDecorator> treeDecorators) {
-            this.treeDecorators = treeDecorators;
-            return this;
-        }
-
-        public Builder replaceFromNBT(Map<Block, BlockStateProvider> placeFromNBT) {
-            this.replaceFromNBT = placeFromNBT;
-            return this;
-        }
-
-        public Builder isSapling(boolean isSapling) {
-            this.isSapling = isSapling;
-            return this;
-        }
-
-        public Builder orientation(Orientation orientation) {
-            this.orientation = orientation;
-            return this;
-        }
+        public Builder baseLocation(ResourceLocation baseLocation) { this.baseLocation = baseLocation; return this; }
+        public Builder canopyLocation(ResourceLocation canopyLocation) { this.canopyLocation = canopyLocation; return this; }
+        public Builder height(IntProvider height) { this.height = height; return this; }
+        public Builder logProvider(BlockStateProvider logProvider) { this.logProvider = logProvider; return this; }
+        public Builder leavesProvider(List<BlockStateProvider> leavesProvider) { this.leavesProvider = leavesProvider; return this; }
+        public Builder logTarget(Set<Block> logTarget) { this.logTarget = logTarget; return this; }
+        public Builder leavesTarget(List<Block> leavesTarget) { this.leavesTarget = leavesTarget; return this; }
+        public Builder growableOn(BlockPredicate growableOn) { this.growableOn = growableOn; return this; }
+        public Builder leavesPlacementFilter(BlockPredicate leavesPlacementFilter) { this.leavesPlacementFilter = leavesPlacementFilter; return this; }
+        public Builder maxLogDepth(int maxLogDepth) { this.maxLogDepth = maxLogDepth; return this; }
+        public Builder treeDecorators(List<TreeDecorator> treeDecorators) { this.treeDecorators = treeDecorators; return this; }
+        public Builder replaceFromNBT(Map<Block, BlockStateProvider> replaceFromNBT) { this.replaceFromNBT = replaceFromNBT; return this; }
+        public Builder isSapling(boolean isSapling) { this.isSapling = isSapling; return this; }
+        public Builder orientation(Orientation orientation) { this.orientation = orientation; return this; }
+        public Builder randomRotation(boolean randomRotation) { this.randomRotation = randomRotation; return this; }
 
         public TreeFromStructureNBTConfigV2 build() {
-            if (baseLocation == null) {
-                throw new IllegalStateException("Base location cannot be null");
-            }
-            if (canopyLocation == null) {
-                throw new IllegalStateException("Canopy location cannot be null");
-            }
-            if (height == null) {
-                throw new IllegalStateException("Height cannot be null");
-            }
-            if (logProvider == null) {
-                throw new IllegalStateException("Log provider cannot be null");
-            }
-            if (leavesProvider == null) {
-                throw new IllegalStateException("Leaves provider cannot be null");
-            }
-            if (logTarget == null) {
-                throw new IllegalStateException("Log target cannot be null");
-            }
-            if (leavesTarget == null) {
-                throw new IllegalStateException("Leaves target cannot be null");
+            if (baseLocation == null || canopyLocation == null || height == null || logProvider == null || leavesProvider == null || logTarget == null || leavesTarget == null) {
+                throw new IllegalStateException("Missing required parameters for TreeFromStructureNBTConfigV2");
             }
 
             return new TreeFromStructureNBTConfigV2(
@@ -184,6 +108,7 @@ public record TreeFromStructureNBTConfigV2(ResourceLocation baseLocation, Resour
                     treeDecorators,
                     replaceFromNBT,
                     isSapling,
+                    randomRotation,
                     orientation
             );
         }


### PR DESCRIPTION
Introduce a random_rotation boolean to TreeFromStructureNBTConfig and TreeFromStructureNBTConfigV2 (default true) and expose it via the codec and Builder APIs. Features now respect the flag: when false the structure rotation is fixed to Rotation.NONE, otherwise a random rotation is used. Also update constructors/builders to pass the new parameter, add builder methods for randomRotation, and tidy up some builder field formatting and V2 validation error handling.